### PR TITLE
all FlashFS functions now use one shared buffer

### DIFF
--- a/DevelOS.h
+++ b/DevelOS.h
@@ -29,7 +29,7 @@ extern "C" {
 #define REFval 10
 
 #define BOOT_SLOW                           // This will add some delays to the startup process
-#define Slowboot            10000            // how slow shall i boot?
+#define Slowboot            1000            // how slow shall i boot?
 #define Startmode           RL_Standby      // OS shall switch to this after booting
 #define ResetToken          0xAA            // this is for resetting the os in debug
 #define EventBuffer         8              // Length of the internal Event Queue

--- a/FlashFS.h
+++ b/FlashFS.h
@@ -16,9 +16,19 @@ extern "C" {
 #ifdef MOD_FlashFS
 
     #define EE_Blocksize        64
-    #define EE_Blocks           16       // 256 Byte 
-    //#define EE_bytes_System     21      // 21 bytes used for now, 15 system, 6 rtc TODO: assign dynamically
 
+    // <editor-fold defaultstate="collapsed" desc="Set number of blocks according to processor type">
+#if defined EE_1k
+    #define EE_Blocks           16       
+#elif defined EE_256
+    #define EE_Blocks           4
+#elif defined EE_128
+    #define EE_Blocks           2
+#else
+    #define EE_Blocks           0
+#endif
+//</editor-fold>
+    
     // Block signatures
     #define EE_sig_FlashFS      0x01
     #define EE_sig_System       0x02
@@ -28,7 +38,7 @@ extern "C" {
 
     // <editor-fold defaultstate="collapsed" desc="RAM Buffer for Flash Data">
 extern struct Flash_Data {
-    unsigned char Data[EE_Blocksize];   // store FlashFS Data Block here
+    unsigned char Data[EE_Blocksize];   // have a buffer for one block // no longer store FlashFS Data Block here permanently
 
     struct EEPROM {
         unsigned char UsedBlocks;       // internal blocks used
@@ -54,9 +64,11 @@ extern struct Flash_Data {
         // Byte 60  : 8bit  : external adress for last external device. This allows up to 58 external devices
         // Byte 61  : 16bit : CRC checksum for FlashFS Block
         // Byte 63  : 8bit  : FlashFS Signature Byte
+    // these are for the FlashFS Block only
 #define FFS_int_blocks      0
 #define FFS_ext_devices     1
 #define FFS_Device0         2
+    // these are for every block in internal eeprom
 #define FFS_Data_CRC        61   
 #define FFS_signature       63
 

--- a/console.c
+++ b/console.c
@@ -19,7 +19,7 @@ void c_cr(void)
     if(console.cursor_y >= CON_lines)
     {
         console.cursor_y=CON_lines-1;
-        console.display_y = CON_lines - LCD.Dimensions.height;
+        console.display_y = (CON_lines - LCD.Dimensions.height) - 1;
         
         // shift Display Buffer 1 line
         for(i=0; i < CON_lines-1 ;i++)

--- a/eeprom.h
+++ b/eeprom.h
@@ -14,16 +14,22 @@ extern "C" {
 
 #ifdef MOD_FlashFS
 
+void EE_format(void);                                   // format the internal eeprom
+void InitEEPROM(void);                                  // set all the addresses and read signature of each block TODO: also check crc for each block
+char EE_load_block(unsigned char block);                // read one block from eeprom into the buffer. also checks crc
+char EE_save_block(unsigned char block);                // calculate crc and save block to eeprom
+unsigned char LoadEEPROM_OS(unsigned char block);       // Loads data from eeprom directly into OS
+unsigned char SaveEEPROM_OS(unsigned char block);       // Writes OS data to eeprom block
+
+// <editor-fold defaultstate="collapsed" desc="Internal helper functions. Should not be called directly">
 
 unsigned char EE_check(void);
-void EE_format(void);
-unsigned char EE_read_byte(unsigned int eeprom_address);
+unsigned char EE_read_byte(unsigned int eeprom_address);    
 unsigned char EE_read_block(unsigned int eeprom_start_address, unsigned char *ram_start_address, unsigned char len);
 unsigned char EE_write_block (unsigned int eeprom_start_address, unsigned char *ram_start_address, unsigned char len);
 //unsigned char EE_check_block(unsigned int eeprom_start_address, unsigned char len);
-unsigned char LoadEEPROM_OS(unsigned char block);
-unsigned char SaveEEPROM_OS(unsigned char block);
-void InitEEPROM(void);
+
+//</editor-fold>
 
 #endif /* MOD_FlashFS */
 

--- a/hardware.h
+++ b/hardware.h
@@ -63,6 +63,18 @@ extern "C" {
 #endif
 
 #ifdef MOD_FlashFS
+    // <editor-fold defaultstate="collapsed" desc="Processor specific #defines">    
+#if defined(__18F46K20)
+    // <editor-fold defaultstate="collapsed" desc="PIC18F 46K20">
+    #define	EE_1k
+// </editor-fold>
+#elif defined(__18F4550)
+    // <editor-fold defaultstate="collapsed" desc="PIC18F 4550">
+#define EE_256
+// </editor-fold>
+#endif
+// </editor-fold>
+
     // TODO: if no internal eeprom is present, emulate it in program flash
     #include "./FlashFS.h"
     #include "./eeprom.h"
@@ -219,22 +231,7 @@ extern "C" {
     #include "eeprom_i2c.h"
 #endif /* MOD_FlashFS_extI2C */
     // </editor-fold>
-   
-    // These configure EEPROM size for each processor
-    // can also be used to configure other chip-specific stuff
-    
-// <editor-fold defaultstate="collapsed" desc="Processor specific #defines">    
-#if defined(__18F46K20)
-    // <editor-fold defaultstate="collapsed" desc="PIC18F 46K20">
-    #define	EE_1k
-// </editor-fold>
-#elif defined(__18F4550)
-    // <editor-fold defaultstate="collapsed" desc="PIC18F 4550">
-#define EE_256
-// </editor-fold>
-#endif
-// </editor-fold>
-        
+           
 #ifdef	__cplusplus
 }
 #endif

--- a/newmain.c
+++ b/newmain.c
@@ -318,14 +318,14 @@ void main(void)
                             if(err != 0)
                             {
                                 // no luck, handle error
-                                if(err==-1)
+                                if(err==-2)
                                 {
                                     // no FlashFS Data Block found
                                     sysprint(0, sysstr_formating, 0);
                                     c_cr();
                                     EE_format();
                                 }
-                                else if(err==-2)
+                                else if(err==-1)
                                 {
                                     // FlashFS Data Block invalid
                                     sysprint(0, sysstr_corrupt, 0);
@@ -361,7 +361,14 @@ void main(void)
                         }
                         else
                         {
-                            sysprint(0, sysstr_block, 1);
+                            if(i>9)
+                            {
+                                sysprint(0, sysstr_block, 1);
+                            }
+                            else
+                            {
+                                sysprint(0, sysstr_block, 2);
+                            }
                             c_value(i);
                             c_print(":\0");
                             #ifdef BOOT_SLOW


### PR DESCRIPTION
i have also written two new funtions, EE_load_block and EE_save_block, both take just a block number as argument. crc16 checksum is automatically generated and checked. 
all EEPROM functions now use FlashFS.Data[] as buffer.
access to EEPROM is extremely easy now.
just EE_load_block(<your-block>), if it returns zero, the data is valid and stored in FlashFS.Data[].
on saving, write your data to FlashFS.Data[], leave bytes 61 and 62 free for the checksum, and put your signature in byte 63. then call EE_save_block(<your-block>).
keep in mind that blocks 0 and 1 are used for FlashFS and DevelOS, repectively.
